### PR TITLE
Adds version endpoint

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -22,6 +22,23 @@ paths:
       responses:
         '200':
           description: OK
+  /version:
+    get:
+      tags:
+        - System Status
+      summary: Fetch the API version
+      description: Return the version number for the current API
+      operationId: version
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Version'
+              examples:
+                version 0.1:
+                  $ref: '#/components/examples/Version'
   /pipeline/{pipelineId}:
     get:
       tags:
@@ -95,6 +112,10 @@ components:
     MissingResourceError:
       description: A running resource was not found with the given ID
   examples:
+    Version:
+      description: Version 0.1
+      value:
+        version: "0.1"
     ETLPipeline:
       summary: A generic ETL Pipeline
       value:
@@ -129,6 +150,15 @@ components:
         instances: 2
         status: running
   schemas:
+    Version:
+      required:
+        - version
+      properties:
+        version:
+          type: string
+          pattern: ^\d*\.\d*$
+      example:
+        $ref: '#/components/examples/Version/value'
     Node:
       required:
         - id


### PR DESCRIPTION
Adds a basic version endpoint that responds with the `major.minor` version. The patch number is explicitly left out.

Closes #10 