### PR TITLE
Adds default rulesets to spectral linting workflow

### DIFF
--- a/.github/workflows/OpenAPI.yml
+++ b/.github/workflows/OpenAPI.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           image: stoplight/spectral:latest
           options: -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }}
-          run: spectral lint --ruleset .spectral.yml *.yml
+          run: spectral lint *.yml --fail-severity warn

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,1 +1,1 @@
-extends: ["https://unpkg.com/@apisyouwonthate/style-guide@1.3.2/dist/ruleset.js"]
+extends: ["spectral:oas", "spectral:asyncapi", "https://unpkg.com/@apisyouwonthate/style-guide@1.3.2/dist/ruleset.js"]

--- a/api.yml
+++ b/api.yml
@@ -123,9 +123,16 @@ components:
         launched: 2020-07-21T17:32:28Z
         status: running
         nodes: [
-          $ref: '#/components/examples/ExtractNode/value',
-          $ref: '#/components/examples/TransformNode/value',
-          $ref: '#/components/examples/LoadNode/value',
+          {
+            node: "0x7f5023953990",
+            downstream: [ "0x7f50239539b0" ]
+          },{
+            node: "0x7f50239539b0",
+            downstream: [ "0x7f502385e910" ]
+          },{
+            node: "0x7f502385e910",
+            downstream: [ ]
+          },
         ]
     ExtractNode:
       summary: Extract node for an ETL pipeline
@@ -180,7 +187,7 @@ components:
           type: integer
         status:
           type: string
-          enum: [ 'launching', 'running', 'finished', 'errored', 'unknown' ]
+          enum: [ 'launching', 'running', 'stopped', 'errored', 'unknown' ]
       example:
         $ref: '#/components/examples/ExtractNode/value'
     # Meta data for a given pipeline
@@ -203,23 +210,25 @@ components:
         launched:
           type: string
           format: date-time
-          pattern: $\d4-\d2-\d2-\d2:\d2:\d2$
+          pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$
         status:
           type: string
-          enum: [ 'launching', 'running', 'finished', 'degraded', 'errored', 'unknown' ]
+          enum: [ 'launching', 'running', 'stopped', 'degraded', 'errored', 'unknown' ]
         nodes: # Mapping of pipeline node IDs to downstream node IDs
-          type: object
-          required:
-            - node
-            - downstream
-          properties:
-            node:
-              type: string
-            downstream:
-              type: array
-              items:
+          type: array
+          items:
+            type: object
+            required:
+              - node
+              - downstream
+            properties:
+              node:
                 type: string
-              uniqueItems: true
+              downstream:
+                type: array
+                items:
+                  type: string
+                uniqueItems: true
       example:
         $ref: '#/components/examples/ETLPipeline/value'
   securitySchemes:

--- a/api.yml
+++ b/api.yml
@@ -2,6 +2,8 @@ openapi: 3.0.3
 info:
   title: Egon Status API
   version: 0.0.1
+  contact:
+    url: https://github.com/Egon-Framework/status-api
   description: |-
     API specification for monitoring the Egon Framework.
     

--- a/api.yml
+++ b/api.yml
@@ -1,11 +1,17 @@
 openapi: 3.0.3
 info:
   title: Egon Status API
+  version: 0.0.1
   description: |-
     API specification for monitoring the Egon Framework.
     
     For more information, checkout the source code [on GitHub](https://github.com/Egon-Framework/status-api)
-  version: 0.0.1
+servers:
+  - url: https://{url}/V0
+    variables:
+      url:
+        default: localhost
+        description: The base API URL
 tags:
   - name: Documentation
     description: Endpoints that direct users to the documentation or other helpful information

--- a/api.yml
+++ b/api.yml
@@ -7,11 +7,28 @@ info:
     For more information, checkout the source code [on GitHub](https://github.com/Egon-Framework/status-api)
   version: 0.0.1
 tags:
+  - name: Documentation
+    description: Endpoints that direct users to the documentation or other helpful information
   - name: System Status
     description: Retrieve information concerning the Egon API backend
   - name: Pipeline Metadata
     description: Metadata and status information for currently running pipeline components
 paths:
+  /:
+    get:
+      tags:
+        - Documentation
+      summary: Base API URL
+      description: The base API URL pointing users at the documentation
+      operationId: root
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: 'The Egon Framework status API. See https://egon-framework.github.io/status-api/ for more details.'
   /health:
     get:
       tags:
@@ -31,7 +48,7 @@ paths:
       operationId: version
       responses:
         '200':
-          description: success
+          description: OK
           content:
             application/json:
               schema:
@@ -57,7 +74,7 @@ paths:
             type: string
       responses:
         '200':
-          description: success
+          description: OK
           content:
             application/json:
               schema:
@@ -87,7 +104,7 @@ paths:
             type: string
       responses:
         '200':
-          description: success
+          description: OK
           content:
             application/json:
               schema:


### PR DESCRIPTION
The default spectral rulesets were accidentally left out in the `.spectral.yml` config file. This PR adds the default rulesets and fixes some linting errors that weren't caught earlier due to the missing linting rules.