### PR TITLE
Make README match the server URL specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install -g @stoplight/prism-cli
 Then spin up a local instance as follows:
 
 ```bash
-prism mock api.yml
+prism mock api.yml -p 4010
 ```
 
 When performing queries against the mock session, don't forget to provide a dummy auth token.

--- a/api.yml
+++ b/api.yml
@@ -9,11 +9,15 @@ info:
     
     For more information, checkout the source code [on GitHub](https://github.com/Egon-Framework/status-api)
 servers:
-  - url: https://{url}/V0
+  - url: https://{url}:{port}/V0
+    description: A local development server
     variables:
       url:
         default: localhost
         description: The base API URL
+      port:
+        default: '4010'
+        description: The API port number
 tags:
   - name: Documentation
     description: Endpoints that direct users to the documentation or other helpful information


### PR DESCRIPTION
Updates the README and server URL specification so the development server URL and port numbers are the same between both documents.