### PR TITLE
Updates ID fields to use UUID4 format

### DIFF
--- a/api/v0.yml
+++ b/api/v0.yml
@@ -200,7 +200,7 @@ components:
       properties:
         version:
           type: string
-          pattern: ^\d*\.\d*$
+          pattern: ^\d*\.\d*$ # Major and minor version only
       example:
         $ref: '#/components/examples/Version/value'
     Node: # Meta data for a given node
@@ -259,12 +259,12 @@ components:
             properties:
               node:
                 type: string
-                pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$
+                pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
               downstream:
                 type: array
                 items:
                   type: string
-                  pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$
+                  pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
                 uniqueItems: true
       example:
         $ref: '#/components/examples/ETLPipeline/value'

--- a/api/v0.yml
+++ b/api/v0.yml
@@ -194,8 +194,7 @@ components:
         instances: 2
         status: running
   schemas:
-    # The API version number
-    Version:
+    Version: # The API version number
       required:
         - version
       properties:
@@ -204,8 +203,7 @@ components:
           pattern: ^\d*\.\d*$
       example:
         $ref: '#/components/examples/Version/value'
-    # Meta data for a given node
-    Node:
+    Node: # Meta data for a given node
       required:
         - id
         - name
@@ -215,6 +213,7 @@ components:
       properties:
         id:
           type: string
+          pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
         name:
           type: string
         description:
@@ -223,11 +222,10 @@ components:
           type: integer
         status:
           type: string
-          enum: [ 'launching', 'running', 'stopped', 'errored', 'unknown' ]
+          enum: [ 'launching', 'running', 'stopped', 'degraded', 'errored', 'unknown' ]
       example:
         $ref: '#/components/examples/ExtractNode/value'
-    # Meta data for a given pipeline
-    Pipeline:
+    Pipeline: # Meta data for a given pipeline
       required:
         - id
         - name
@@ -239,6 +237,7 @@ components:
       properties:
         id:
           type: string
+          pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
         name:
           type: string
         description:
@@ -260,10 +259,12 @@ components:
             properties:
               node:
                 type: string
+                pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$
               downstream:
                 type: array
                 items:
                   type: string
+                  pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$
                 uniqueItems: true
       example:
         $ref: '#/components/examples/ETLPipeline/value'

--- a/api/v0.yml
+++ b/api/v0.yml
@@ -153,27 +153,27 @@ components:
     ETLPipeline:
       summary: A generic ETL Pipeline
       value:
-        id: "0x7f50239539d0"
+        id: "57d92d7e-58c0-48ec-bed2-2e8b507161bb"
         name: ETL Pipeline
         description: An ETL pipeline with three nodes
         launched: 2020-07-21T17:32:28Z
         status: running
         nodes: [
           {
-            node: "0x7f5023953990",
-            downstream: [ "0x7f50239539b0" ]
+            node: 760c45a4-9a65-418f-a442-aa8c3f22cad2,
+            downstream: [ 1da5a095-00af-45fe-ba1b-ea9576439f75 ]
           },{
-            node: "0x7f50239539b0",
-            downstream: [ "0x7f502385e910" ]
+            node: 1da5a095-00af-45fe-ba1b-ea9576439f75,
+            downstream: [ ae3de17e-1c7a-4817-b619-b5aa984ffe51 ]
           },{
-            node: "0x7f502385e910",
+            node: ae3de17e-1c7a-4817-b619-b5aa984ffe51,
             downstream: [ ]
           },
         ]
     ExtractNode:
       summary: Extract node for an ETL pipeline
       value:
-        id: "0x7f5023953990"
+        id: 760c45a4-9a65-418f-a442-aa8c3f22cad2
         name: Extract
         description: Load data into the pipeline
         instances: 1
@@ -181,7 +181,7 @@ components:
     TransformNode:
       summary: Transform node in an ETL pipeline
       value:
-        id: "0x7f50239539b0"
+        id: 1da5a095-00af-45fe-ba1b-ea9576439f75
         name: Transform
         description: Transform and analyze pipeline data
         instances: 4
@@ -189,7 +189,7 @@ components:
     LoadNode:
       summary: The load step in an ETL pipeline
       value:
-        id: "0x7f502385e910"
+        id: ae3de17e-1c7a-4817-b619-b5aa984ffe51
         name: Load
         instances: 2
         status: running


### PR DESCRIPTION
The Egon Python API is going to use UUID4 for ID generation. The REST API should be consistent.