### PR TITLE
Adds specific responses for missing resources and authentication errors

### DIFF
--- a/api/v0.yml
+++ b/api/v0.yml
@@ -152,6 +152,11 @@ components:
             enum: [ Authentication failed ]
     MissingResourceError:
       description: Resource not found
+      content:
+        text/plain:
+          schema:
+            type: string
+            enum: [ Resource not found ]
   examples:
     Version:
       description: Version 0.1

--- a/api/v0.yml
+++ b/api/v0.yml
@@ -145,6 +145,11 @@ components:
   responses:
     UnauthorizedError:
       description: Authentication information is missing or invalid
+      content:
+        text/plain:
+          schema:
+            type: string
+            enum: [ Authentication failed ]
     MissingResourceError:
       description: Resource not found
   examples:


### PR DESCRIPTION
The `UnauthorizedError` and `MissingResourceError` responses were missing the `content` field. This PR adds the missing field.