### PR TITLE
Fixes typo in token query parameter name

### DIFF
--- a/api/v0.yml
+++ b/api/v0.yml
@@ -348,7 +348,7 @@ components:
     TokenQueryAuth:
       type: apiKey
       in: query
-      name: User Token
+      name: token
       description: |-
         API tokens are temporary and limited in scope.
         User tokens provide access to information concerning a single running pipeline.


### PR DESCRIPTION
Looks like the name of the `token` parameter was accidentally changed during a documentation pass. This PR changes it back.