### PR TITLE
Makes pipeline endpoint postable

### DIFF
--- a/api/v0.1.yml
+++ b/api/v0.1.yml
@@ -129,9 +129,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Pipeline'
-              examples:
-                etl:
-                  $ref: '#/components/examples/ETLPipeline'
       responses:
         '201':
           description: Created

--- a/api/v0.1.yml
+++ b/api/v0.1.yml
@@ -107,6 +107,31 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '404':
           $ref: '#/components/responses/MissingResourceError'
+    post:
+      tags:
+        - Pipeline Metadata
+      security:
+        - TokenQueryAuth: [ ]
+      summary: Store new pipeline metadata
+      description: Store information for a new pipeline with the provided metadata.
+      operationId: createPipeline
+      parameters:
+        - name: pipelineId
+          in: path
+          description: Pipeline ID to store data for
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Pipeline metadata
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pipeline'
+              examples:
+                etl:
+                  $ref: '#/components/examples/ETLPipeline'
   /node/{nodeID}:
     get:
       tags:

--- a/api/v0.1.yml
+++ b/api/v0.1.yml
@@ -132,6 +132,11 @@ paths:
               examples:
                 etl:
                   $ref: '#/components/examples/ETLPipeline'
+      responses:
+        '201':
+          description: Created
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
   /node/{nodeID}:
     get:
       tags:


### PR DESCRIPTION
Allows the storage of new pipeline via a POST to the `/pipeline` endpoint.  