### PR TITLE
Updates UUID regex to be more specific

### DIFF
--- a/api/v0.1.yml
+++ b/api/v0.1.yml
@@ -298,7 +298,7 @@ components:
       properties:
         id:
           type: string
-          pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
         name:
           type: string
         description:
@@ -322,18 +322,18 @@ components:
       properties:
         upstream_node:
           type: string
-          pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
         output_id:
           type: string
-          pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
         output_name:
           type: string
         downstream_node:
           type: string
-          pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
         input_id:
           type: string
-          pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
         input_name:
           type: string
     Pipeline: # Meta data for a given pipeline
@@ -348,7 +348,7 @@ components:
       properties:
         id:
           type: string
-          pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
         name:
           type: string
         description:
@@ -364,7 +364,7 @@ components:
           type: array
           items:
             type: string
-            pattern: ^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
+            pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
         edges:
           type: array
           items:

--- a/api/v0.1.yml
+++ b/api/v0.1.yml
@@ -298,7 +298,7 @@ components:
       properties:
         id:
           type: string
-          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
         name:
           type: string
         description:
@@ -322,18 +322,18 @@ components:
       properties:
         upstream_node:
           type: string
-          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
         output_id:
           type: string
-          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
         output_name:
           type: string
         downstream_node:
           type: string
-          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
         input_id:
           type: string
-          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
         input_name:
           type: string
     Pipeline: # Meta data for a given pipeline
@@ -348,7 +348,7 @@ components:
       properties:
         id:
           type: string
-          pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
+          pattern: ^[\da-f]{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
         name:
           type: string
         description:
@@ -364,7 +364,7 @@ components:
           type: array
           items:
             type: string
-            pattern: ^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$ # UUID4 format
+            pattern: ^[\da-f]{8}-\w{4}-\w{4}-\w{4}-\w{12}$ # UUID4 format
         edges:
           type: array
           items:


### PR DESCRIPTION
The UUID regex pattern has been changed from:

```^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$```

to

```^[\da-f]{8}-\w{4}-\w{4}-\w{4}-\w{12}$```


The new pattern uses the character class [\da-f] to match any lowercase hexadecimal digit (a-f) or digit (0-9). This allows for a more specific validation of the UUID format.